### PR TITLE
fix(ci): add missing build dependencies for auto-prerelease workflow

### DIFF
--- a/.github/workflows/auto-prerelease.yml
+++ b/.github/workflows/auto-prerelease.yml
@@ -71,12 +71,15 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq \
+          build-essential \
           dpkg-dev \
           debhelper \
           dh-python \
           python3-all \
           python3-apt \
-          python3-hatchling
+          python3-hatchling \
+          nodejs \
+          npm
 
     - name: Build frontend
       if: steps.check.outputs.action == 'create'


### PR DESCRIPTION
## Summary

Fixes the auto-prerelease workflow failures caused by missing build dependencies.

## Problem

The auto-prerelease workflow was failing with:
```
dpkg-checkbuilddeps: error: Unmet build dependencies: build-essential:native nodejs npm
```

All recent workflow runs failed because `dpkg-buildpackage` couldn't find required build dependencies.

## Solution

Added missing packages that `debian/control` Build-Depends requires:
- **build-essential**: provides gcc, g++, make and other essential build tools
- **nodejs**: required by debian/control Build-Depends
- **npm**: required by debian/control Build-Depends

## Technical Notes

We already use `actions/setup-node@v4` to install Node.js 18 for the frontend build, but `dpkg-buildpackage` specifically checks for system packages listed in `debian/control`. Both installations are needed:
- System packages satisfy dpkg-buildpackage's dependency check
- actions/setup-node provides the specific Node.js version for the build

## Testing

- [x] Commit created with proper conventional commit format
- [ ] Will verify workflow passes after merge

## Related

Fixes the issues reported in workflow runs:
- https://github.com/hatlabs/cockpit-apt/actions/runs/19395274679
- https://github.com/hatlabs/cockpit-apt/actions/runs/19395254037
- https://github.com/hatlabs/cockpit-apt/actions/runs/19395211651
- https://github.com/hatlabs/cockpit-apt/actions/runs/19395189305

🤖 Generated with [Claude Code](https://claude.com/claude-code)