### PR TITLE
fix(ci): use PAT to trigger release.yml from auto-prerelease

### DIFF
--- a/.github/workflows/auto-prerelease.yml
+++ b/.github/workflows/auto-prerelease.yml
@@ -56,7 +56,7 @@ jobs:
         echo "action=create" >> $GITHUB_OUTPUT
         echo "✅ No published release with same or higher version - will create pre-release v${TAG_VERSION}"
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.REPO_DISPATCH_PAT }}
 
     - name: Setup Node.js
       if: steps.check.outputs.action == 'create'
@@ -153,7 +153,7 @@ jobs:
 
         echo "Release notes created"
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.REPO_DISPATCH_PAT }}
 
     - name: Delete existing pre-release
       if: steps.check.outputs.action == 'create'
@@ -169,7 +169,7 @@ jobs:
           fi
         fi
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.REPO_DISPATCH_PAT }}
 
     - name: Create pre-release
       if: steps.check.outputs.action == 'create'
@@ -191,7 +191,7 @@ jobs:
 
         echo "✅ Pre-release created successfully"
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.REPO_DISPATCH_PAT }}
 
     - name: Report success
       if: steps.check.outputs.action == 'create'


### PR DESCRIPTION
## Summary

Fixes the issue where auto-prerelease workflow successfully creates pre-releases but doesn't trigger the release.yml workflow to dispatch to apt.hatlabs.fi.

## Problem

After PR #47, the auto-prerelease workflow builds and creates pre-releases successfully, but the release.yml workflow is never triggered, so no dispatch to apt.hatlabs.fi happens.

**Root Cause**: GitHub workflows using the default `GITHUB_TOKEN` cannot trigger other workflows. This is a security feature to prevent recursive workflow runs.

From GitHub docs:
> Events triggered by the GITHUB_TOKEN will not create a new workflow run.

## Solution

Use `REPO_DISPATCH_PAT` (the same PAT used in release.yml for dispatching) instead of `github.token` for all release operations in auto-prerelease.yml.

This allows the created pre-release to trigger the `release.published` event, which starts the release.yml workflow to dispatch to apt.hatlabs.fi unstable channel.

## Changes

Changed all `GH_TOKEN` references in auto-prerelease.yml from:
```yaml
GH_TOKEN: ${{ github.token }}
```

To:
```yaml
GH_TOKEN: ${{ secrets.REPO_DISPATCH_PAT }}
```

This affects 4 steps:
- ✅ Check if published release exists
- ✅ Generate release notes  
- ✅ Delete existing pre-release
- ✅ **Create pre-release** (critical for triggering release.yml)

## Testing

- [x] Changes committed with proper conventional commit format
- [ ] Will verify release.yml triggers after merge

## Expected Flow After Fix

```
Push to main
  ↓
auto-prerelease.yml runs
  ↓
Creates pre-release using PAT
  ↓
[GitHub 'release.published' event fires]
  ↓
release.yml workflow triggers
  ↓
Dispatches to apt.hatlabs.fi unstable channel
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)