### PR TITLE
fix(ci): use trixie distro for APT repository dispatch

### DIFF
--- a/.github/workflows/auto-prerelease.yml
+++ b/.github/workflows/auto-prerelease.yml
@@ -203,7 +203,7 @@ jobs:
         client-payload: |
           {
             "repository": "${{ github.repository }}",
-            "distro": "any",
+            "distro": "trixie",
             "channel": "unstable",
             "component": "main"
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         client-payload: |
           {
             "repository": "${{ github.repository }}",
-            "distro": "any",
+            "distro": "trixie",
             "channel": "stable",
             "component": "main"
           }


### PR DESCRIPTION
## Summary

Fixes incorrect APT distribution targeting. Packages were going to `unstable/main` instead of `trixie-unstable/main`.

## Problem

The dispatch payload was using:
```json
{
  "distro": "any",
  "channel": "unstable"
}
```

This caused packages to be published to the generic `unstable` distribution instead of the Debian release-specific `trixie-unstable` distribution.

## Solution

Changed `distro` from `"any"` to `"trixie"` in both workflows:

**auto-prerelease.yml:**
- `distro: "trixie"` + `channel: "unstable"` → targets `trixie-unstable/main`

**release.yml:**
- `distro: "trixie"` + `channel: "stable"` → targets `trixie-stable/main`

## Distribution Mapping

According to apt.hatlabs.fi configuration:
- `distro: "trixie"` + `channel: "unstable"` → `trixie-unstable` distribution
- `distro: "trixie"` + `channel: "stable"` → `trixie-stable` distribution
- `distro: "any"` + `channel: "unstable"` → `unstable` distribution (generic)

## Testing

- [x] Changes committed with proper conventional commit format
- [ ] Will verify packages appear in trixie-unstable after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)