### PR TITLE
fix(ui): match skeleton card grid breakpoints to actual cards

### DIFF
--- a/frontend/src/components/LoadingSkeleton.tsx
+++ b/frontend/src/components/LoadingSkeleton.tsx
@@ -144,7 +144,7 @@ export const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
     return (
       <Grid hasGutter className={className}>
         {Array.from({ length: rows }).map((_, index) => (
-          <GridItem key={index} md={6} lg={4} xl={3}>
+          <GridItem key={index} sm={6} md={4} lg={3} xl={2}>
             <CardSkeleton />
           </GridItem>
         ))}


### PR DESCRIPTION
## Summary

Fix layout shift when skeleton loading cards transition to actual cards by matching their grid item breakpoints.

## Problem

The skeleton/placeholder cards use different grid breakpoints than actual CategoryCard and SectionCard components, causing a jarring layout shift when data finishes loading.

## Solution

Update skeleton card GridItem breakpoints to match actual cards:
- Before: `md={6} lg={4} xl={3}` (missing small breakpoint)
- After: `sm={6} md={4} lg={3} xl={2}` (matches actual cards)

## Impact

- Smoother transition from loading to loaded state
- Consistent grid layout across all screen sizes
- Better UX with no visual jarring

## Test Plan

- [ ] Load a section list to see skeleton cards
- [ ] Verify cards have same width as actual loaded cards
- [ ] Test on mobile (small), tablet (medium), and desktop (large) screens
- [ ] Verify no layout shift when data finishes loading
- [ ] Run type checking: `npm run typecheck`

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)