### PR TITLE
fix(test): wait for button element in SectionsView test

### DIFF
--- a/frontend/src/views/__tests__/SectionsView.test.tsx
+++ b/frontend/src/views/__tests__/SectionsView.test.tsx
@@ -517,12 +517,11 @@ describe("SectionsView - Edge Cases", () => {
 
     const { container } = render(<SectionsView />); // No onNavigateToSection prop
 
-    await waitFor(() => {
-      expect(screen.getByText("Browse by Section")).toBeInTheDocument();
-    });
+    // Wait for the button to be rendered (not just the heading)
+    // The heading is always rendered, but the button is only rendered after data loads
+    const card = await screen.findByRole("button", { name: /View.*web/i });
 
     // Click on a section card - should not crash
-    const card = screen.getByRole("button", { name: /View.*web/i });
     card.click();
 
     // Component should still be rendered


### PR DESCRIPTION
## Summary

Fixes the failing frontend CI test in SectionsView.test.tsx by properly waiting for the button element to render before attempting to interact with it.

## Problem

The test was failing with:
```
Unable to find an accessible element with role 'button' and name /View.*web/i
```

The test expected a button matching the pattern `/View.*web/i`, but the rendered DOM contained only skeleton loading cards and the heading "Browse by Section".

## Root Cause

**Timing issue:** The test incorrectly assumed the button element was already available immediately after the heading appeared.

- The heading "Browse by Section" is rendered ALWAYS (line 399 of SectionsView.tsx), regardless of loading state
- The button/card elements are only rendered AFTER data has been fetched and `loading` state becomes `false` (lines 413-454)
- The test used `screen.getByRole()` which expects the element to already exist
- The test should have waited for the element to appear

## Solution

Changed from `screen.getByRole()` (immediate lookup) to `screen.findByRole()` (waits for element) to properly wait for the component to finish loading before attempting to interact with the button.

**Changed:**
```typescript
// Before - fails because heading appears before button
await waitFor(() => {
  expect(screen.getByText("Browse by Section")).toBeInTheDocument();
});
const card = screen.getByRole("button", { name: /View.*web/i });

// After - waits for button to appear
const card = await screen.findByRole("button", { name: /View.*web/i });
```

## Verification

- ✅ All 20 SectionsView tests pass
- ✅ Test pattern `/View.*web/i` now correctly matches the section card's aria-label
- ✅ Component behavior unchanged

Closes #65