### PR TITLE
feat(ci): create main.yml workflow for main branch CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,170 @@
+name: Main Branch CI/CD
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+env:
+  APT_DISTRO: ${{ vars.APT_DISTRO || 'trixie' }}
+  APT_COMPONENT: ${{ vars.APT_COMPONENT || 'main' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        uses: ./.github/actions/run-tests
+
+  build-and-release:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from debian/changelog
+        id: version
+        run: .github/scripts/read-version.sh
+
+      - name: Check if published release exists
+        id: check
+        run: .github/scripts/check-release-exists.sh "${{ steps.version.outputs.version }}" prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Setup Node.js
+        if: steps.check.outputs.action == 'create'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: 'frontend/package-lock.json'
+
+      - name: Build frontend
+        if: steps.check.outputs.action == 'create'
+        run: .github/scripts/build-frontend.sh
+
+      - name: Build .deb package
+        if: steps.check.outputs.action == 'create'
+        run: .github/scripts/build-deb-package.sh
+
+      - name: Rename package with distro+component suffix
+        if: steps.check.outputs.action == 'create'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          OLD_NAME="../cockpit-apt_${VERSION}_all.deb"
+          NEW_NAME="../cockpit-apt_${VERSION}_all+${APT_DISTRO}+${APT_COMPONENT}.deb"
+
+          if [ -f "$OLD_NAME" ]; then
+            echo "📦 Renaming package: $(basename $OLD_NAME) → $(basename $NEW_NAME)"
+            mv "$OLD_NAME" "$NEW_NAME"
+            echo "✅ Package renamed successfully"
+            echo "Package location: $NEW_NAME"
+          else
+            echo "❌ Error: Expected package not found: $OLD_NAME"
+            exit 1
+          fi
+
+      - name: Generate release notes
+        if: steps.check.outputs.action == 'create'
+        id: notes
+        run: .github/scripts/generate-release-notes.sh "${{ steps.version.outputs.version }}" "${{ steps.version.outputs.tag_version }}" prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Delete existing pre-release
+        if: steps.check.outputs.action == 'create'
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
+          if gh release view "v${TAG_VERSION}" &>/dev/null; then
+            IS_PRERELEASE=$(gh release view "v${TAG_VERSION}" --json isPrerelease --jq '.isPrerelease')
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              echo "🗑️  Deleting existing pre-release v${TAG_VERSION}"
+              gh release delete "v${TAG_VERSION}" --yes --cleanup-tag
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create pre-release
+        if: steps.check.outputs.action == 'create'
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
+          if ! ls ../*.deb 1> /dev/null 2>&1; then
+            echo "❌ Error: No .deb files found"
+            exit 1
+          fi
+          echo "📦 Creating pre-release v${TAG_VERSION}"
+          gh release create "v${TAG_VERSION}" \
+            --prerelease \
+            --title "v${TAG_VERSION} (Pre-release)" \
+            --notes-file release_notes.md \
+            ../*.deb
+          echo "✅ Pre-release created successfully"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create draft release
+        if: steps.check.outputs.action == 'create'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
+
+          # Check if draft release already exists
+          if gh release view "v${VERSION}" &>/dev/null; then
+            IS_DRAFT=$(gh release view "v${VERSION}" --json isDraft --jq '.isDraft')
+            IS_PRERELEASE=$(gh release view "v${VERSION}" --json isPrerelease --jq '.isPrerelease')
+
+            if [ "$IS_DRAFT" = "true" ] && [ "$IS_PRERELEASE" = "false" ]; then
+              echo "Draft release v${VERSION} already exists, skipping creation"
+            fi
+          else
+            # Generate release notes for draft
+            .github/scripts/generate-release-notes.sh "${VERSION}" "${VERSION}" draft
+
+            echo "📋 Creating draft release v${VERSION}"
+            gh release create "v${VERSION}" \
+              --draft \
+              --title "v${VERSION}" \
+              --notes-file release_notes.md
+            echo "✅ Draft release created successfully"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Dispatch to APT repository
+        if: steps.check.outputs.action == 'create'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.REPO_DISPATCH_PAT }}
+          repository: hatlabs/apt.hatlabs.fi
+          event-type: package-updated
+          client-payload: |
+            {
+              "repository": "${{ github.repository }}",
+              "distro": "${{ env.APT_DISTRO }}",
+              "channel": "unstable",
+              "component": "${{ env.APT_COMPONENT }}"
+            }
+
+      - name: Report success
+        if: steps.check.outputs.action == 'create'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
+          echo "=== Main Branch CI/CD Complete ==="
+          echo "Package version: ${VERSION}"
+          echo "Release tag: v${TAG_VERSION}"
+          echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/v${TAG_VERSION}"
+          echo ""
+          echo "✅ Pre-release created"
+          echo "✅ Draft release created"
+          echo "✅ Dispatched to apt.hatlabs.fi unstable channel"


### PR DESCRIPTION
## Summary

Creates a comprehensive `.github/workflows/main.yml` workflow that handles testing, building, and releasing on the main branch with a test-first approach.

## Changes

**New**: `.github/workflows/main.yml`

### Workflow Structure

**Two Jobs:**

1. **test job**
   - Runs all tests via the `run-tests` composite action
   - Backend tests, linting, and frontend tests

2. **build-and-release job** (depends on test)
   - Only runs if test job succeeds
   - Reads version from debian/changelog
   - Checks if release already exists (skips if duplicate version)
   - Builds frontend and .deb package
   - Renames package with `+distro+component` suffix
   - Generates release notes
   - Creates/updates pre-release with .deb artifact
   - Creates/updates draft release
   - Dispatches to apt.hatlabs.fi APT repository

### Configuration

- **Repository Variables** with sensible defaults:
  - `APT_DISTRO` (default: `trixie`)
  - `APT_COMPONENT` (default: `main`)
- **Permissions**: `contents: write` (required for creating releases)
- **Triggers**: On push to main branch

## Key Features

- ✅ Test-first approach: build only if tests pass
- ✅ Smart release detection: avoids duplicate releases
- ✅ Configurable via repository variables
- ✅ Comprehensive logging and error handling
- ✅ Dispatches to external APT repository for distribution

## Acceptance Criteria

- [x] Workflow created at `.github/workflows/main.yml`
- [x] Triggers on push to main
- [x] Tests run first, build only if tests pass
- [x] Pre-release created with .deb package
- [x] Draft release created
- [x] APT dispatch sent with correct payload
- [x] Uses repository variables with sensible defaults

Fixes #77