### PR TITLE
feat(ci): update release.yml to use repository variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,16 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
+env:
+  APT_DISTRO: ${{ vars.APT_DISTRO || 'trixie' }}
+  APT_COMPONENT: ${{ vars.APT_COMPONENT || 'main' }}
+
 jobs:
   trigger-packaging:
     runs-on: ubuntu-latest
-    env:
-      APT_DISTRO: trixie
-      APT_COMPONENT: main
     # Only handle stable releases - pre-releases are handled by auto-prerelease.yml
     if: ${{ github.event.release.prerelease == false }}
     steps:


### PR DESCRIPTION
## Summary

Updates the release.yml workflow to support configurable APT distribution and component via repository variables with sensible defaults, bringing it in line with the main.yml workflow.

## Changes

**Modified**: `.github/workflows/release.yml`

- Moved environment variables from job level to workflow level for consistency
- Updated APT_DISTRO and APT_COMPONENT to use repository variables:
  - `APT_DISTRO: ${{ vars.APT_DISTRO || 'trixie' }}`
  - `APT_COMPONENT: ${{ vars.APT_COMPONENT || 'main' }}`
- Added explicit `permissions: contents: read` for security
- Dispatch payload already uses these variables, so no additional changes needed

## Benefits

- ✅ Configurable via repository variables without modifying workflow
- ✅ Defaults to `trixie` and `main` if variables not set
- ✅ Consistent with main.yml workflow approach
- ✅ Supports multi-distro scenarios
- ✅ Improved flexibility for different deployment targets

## Acceptance Criteria

- [x] release.yml updated with environment variables
- [x] Dispatch payload uses `${{ env.APT_DISTRO }}` and `${{ env.APT_COMPONENT }}`
- [x] Works without repository variables set (uses defaults)
- [x] Can be overridden via repository variables

Fixes #78