### PR TITLE
fix(ci): remove redundant frontend build from main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,18 +40,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Setup Node.js
-        if: steps.check.outputs.action == 'create'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: 'frontend/package-lock.json'
-
-      - name: Build frontend
-        if: steps.check.outputs.action == 'create'
-        run: .github/scripts/build-frontend.sh
-
       - name: Build .deb package
         if: steps.check.outputs.action == 'create'
         run: .github/scripts/build-deb-package.sh


### PR DESCRIPTION
## Summary

Removes redundant Node.js setup and frontend build steps from the main.yml workflow, as these are now handled internally by the build-deb-package.sh script.

## Problem

The main.yml workflow had separate steps for:
- Setting up Node.js with npm caching
- Building the frontend via build-frontend.sh

However, as of #75, the build-deb-package.sh script now installs all its own build dependencies, including Node.js and npm, and the frontend build happens automatically as part of the dpkg-buildpackage process.

This created redundancy and potential for errors due to having the build process duplicated in two places.

## Changes

**Modified**: `.github/workflows/main.yml`

Removed:
- `Setup Node.js` step (with npm caching)
- `Build frontend` step (via build-frontend.sh)

The build-deb-package.sh script handles:
- Installing Node.js and npm (via apt-get)
- Frontend build (via debian/rules which runs `npm ci && npm run build`)
- All other build dependencies

## Benefits

✅ **Single source of truth**: Build process defined only in build-deb-package.sh
✅ **Simpler workflow**: Fewer steps to maintain
✅ **Faster execution**: Eliminates redundant dependency installation
✅ **Less error-prone**: No risk of version/config mismatch between workflow and script
✅ **Consistency**: Same build process used everywhere

## Testing

The build-deb-package.sh script already contains all necessary build dependencies and build steps, so the .deb package will continue to be built correctly.

## Related

- Builds on #75 which made build-deb-package.sh self-contained
- Part of workflow consolidation effort #73