### PR TITLE
fix(ci): add --repo flag to gh release view command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         id: check_assets
         run: |
           STABLE_TAG="${{ steps.version.outputs.stable_tag }}"
-          ASSET_COUNT=$(gh release view "$STABLE_TAG" --json assets --jq '.assets | length')
+          ASSET_COUNT=$(gh release view "$STABLE_TAG" --repo ${{ github.repository }} --json assets --jq '.assets | length')
 
           if [ "$ASSET_COUNT" -gt 0 ]; then
             echo "has_assets=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The `dispatch-to-apt` job fails when stable releases are published because `gh release view` requires either:
1. Being in a git repository, OR
2. Having `--repo` flag specified

The workflow has neither, causing failures like the one observed in container-packaging-tools:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

See: https://github.com/hatlabs/container-packaging-tools/actions/runs/19548177756/job/55972362596

## Solution

Add `--repo ${{ github.repository }}` flag to explicitly specify which repository to query. This is cleaner than adding a checkout step just for one command.

## Testing

- [ ] Verify workflow syntax is valid
- [ ] Test with next stable release

## Impact

Critical fix - blocks stable release publishing to apt.hatlabs.fi

Related to hatlabs/container-packaging-tools#65