### PR TITLE
fix(ci): add --repo flag to gh release download/upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           PRERELEASE_TAG="${{ steps.version.outputs.prerelease_tag }}"
 
           echo "📥 Downloading .deb from pre-release $PRERELEASE_TAG"
-          gh release download "$PRERELEASE_TAG" --pattern "*.deb"
+          gh release download "$PRERELEASE_TAG" --pattern "*.deb" --repo ${{ github.repository }}
 
           if ! ls *.deb 1> /dev/null 2>&1; then
             echo "❌ Error: No .deb files downloaded from pre-release"
@@ -87,7 +87,7 @@ jobs:
           STABLE_TAG="${{ steps.version.outputs.stable_tag }}"
 
           echo "📤 Uploading .deb to stable release $STABLE_TAG"
-          gh release upload "$STABLE_TAG" *.deb --clobber
+          gh release upload "$STABLE_TAG" *.deb --clobber --repo ${{ github.repository }}
 
           echo "✅ Assets uploaded successfully"
         env:


### PR DESCRIPTION
## Summary

- Add `--repo ${{ github.repository }}` to `gh release download` and `gh release upload` commands in the release workflow
- Fixes workflow failure when copying assets from pre-release to stable release

## Root Cause

The release workflow was failing because `gh release download` and `gh release upload` commands were run without checking out the repository first. Without the `--repo` flag, the `gh` CLI cannot determine which repository to operate on, resulting in:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `check_assets` step already correctly used `--repo ${{ github.repository }}`, but this was missing from the download and upload steps.

## Test plan

- [ ] Merge this PR
- [ ] Delete the failed release v0.2.0+5
- [ ] Publish the draft release again to trigger the workflow
- [ ] Verify the workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)