### PR TITLE
fix(ci): add explicit apt-distro and apt-component

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,5 +10,7 @@ jobs:
     with:
       package-name: cockpit-apt
       package-description: 'Modern Cockpit interface for APT package management on Debian'
+      apt-distro: trixie
+      apt-component: main
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,5 +7,8 @@ on:
 jobs:
   publish:
     uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
+    with:
+      apt-distro: trixie
+      apt-component: main
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}


### PR DESCRIPTION
## Summary
- Add explicit `apt-distro: trixie` and `apt-component: main` to both main.yml and release.yml
- Prepares for making these inputs required in shared-workflows

## Context
Part of a multi-repo update to make apt-distro and apt-component required inputs in shared-workflows, preventing silent fallback to defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)