### PR TITLE
feat(store): add mandatory origin filtering with performance optimization

### DIFF
--- a/backend/cockpit_apt/utils/store_config.py
+++ b/backend/cockpit_apt/utils/store_config.py
@@ -23,7 +23,13 @@ STORE_CONFIG_DIR = Path("/etc/container-apps/stores")
 
 @dataclass
 class StoreFilter:
-    """Filter criteria for a store."""
+    """Filter criteria for a store.
+
+    Origin filtering is mandatory for performance optimization since container
+    packages always come from custom repositories, never from upstream Debian
+    or Raspberry Pi repositories. This enables efficient pre-filtering before
+    applying more expensive tag/section filters.
+    """
 
     include_origins: list[str]
     include_sections: list[str]
@@ -31,16 +37,18 @@ class StoreFilter:
     include_packages: list[str]
 
     def __post_init__(self) -> None:
-        """Validate that at least one filter type is specified."""
-        if not any(
-            [
-                self.include_origins,
-                self.include_sections,
-                self.include_tags,
-                self.include_packages,
-            ]
-        ):
-            raise ValueError("At least one filter type must be specified")
+        """Validate that include_origins is non-empty.
+
+        Container store packages always originate from custom repositories
+        (never from upstream Debian/Raspberry Pi), so origin filtering is
+        mandatory for performance optimization.
+        """
+        if not self.include_origins:
+            raise ValueError(
+                "include_origins is required and must be non-empty. "
+                "Container packages always come from custom repositories, "
+                "enabling performance optimization through origin pre-filtering."
+            )
 
 
 @dataclass

--- a/backend/tests/test_store_filter.py
+++ b/backend/tests/test_store_filter.py
@@ -63,11 +63,11 @@ def test_matches_origin_only():
 
 
 def test_matches_section_only():
-    """Match by section only."""
-    pkg = create_mock_package("test-pkg", section="net")
+    """Match by section only (with mandatory origin)."""
+    pkg = create_mock_package("test-pkg", origin="Test Origin", section="net")
 
     filters = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=["net"],
         include_tags=[],
         include_packages=[],
@@ -78,11 +78,11 @@ def test_matches_section_only():
 
 
 def test_matches_tags_only():
-    """Match by tags only."""
-    pkg = create_mock_package("test-pkg", tags="field::marine, role::app")
+    """Match by tags only (with mandatory origin)."""
+    pkg = create_mock_package("test-pkg", origin="Test Origin", tags="field::marine, role::app")
 
     filters = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=[],
         include_tags=["field::marine"],
         include_packages=[],
@@ -93,11 +93,11 @@ def test_matches_tags_only():
 
 
 def test_matches_explicit_package_only():
-    """Match by explicit package name."""
-    pkg = create_mock_package("signalk-server")
+    """Match by explicit package name (with mandatory origin)."""
+    pkg = create_mock_package("signalk-server", origin="Test Origin")
 
     filters = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=[],
         include_tags=[],
         include_packages=["signalk-server"],
@@ -173,11 +173,11 @@ def test_no_match_origin():
 
 
 def test_no_match_section():
-    """Package doesn't match section filter."""
-    pkg = create_mock_package("test-pkg", section="admin")
+    """Package doesn't match section filter (has matching origin but wrong section)."""
+    pkg = create_mock_package("test-pkg", origin="Test Origin", section="admin")
 
     filters = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=["net", "web"],
         include_tags=[],
         include_packages=[],
@@ -188,11 +188,11 @@ def test_no_match_section():
 
 
 def test_no_match_tags():
-    """Package doesn't match tags filter."""
-    pkg = create_mock_package("test-pkg", tags="field::aviation, role::app")
+    """Package doesn't match tags filter (has matching origin but wrong tags)."""
+    pkg = create_mock_package("test-pkg", origin="Test Origin", tags="field::aviation, role::app")
 
     filters = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=[],
         include_tags=["field::marine"],
         include_packages=[],
@@ -203,11 +203,11 @@ def test_no_match_tags():
 
 
 def test_no_match_package_name():
-    """Package doesn't match explicit package list."""
-    pkg = create_mock_package("other-package")
+    """Package doesn't match explicit package list (has matching origin but wrong name)."""
+    pkg = create_mock_package("other-package", origin="Test Origin")
 
     filters = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=[],
         include_tags=[],
         include_packages=["signalk-server", "grafana"],
@@ -233,7 +233,7 @@ def test_matches_with_missing_metadata():
 
     # Should fail section filter
     filters2 = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=["net"],
         include_tags=[],
         include_packages=[],
@@ -243,7 +243,7 @@ def test_matches_with_missing_metadata():
 
     # Should fail tags filter
     filters3 = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=[],
         include_tags=["field::marine"],
         include_packages=[],
@@ -253,11 +253,11 @@ def test_matches_with_missing_metadata():
 
 
 def test_matches_explicit_package_ignores_missing_metadata():
-    """Explicit package match works even with missing metadata."""
-    pkg = create_mock_package("signalk-server")  # No other metadata
+    """Explicit package match works even with missing metadata (except origin)."""
+    pkg = create_mock_package("signalk-server", origin="Test Origin")  # Has origin, no other metadata
 
     filters = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=[],
         include_tags=[],
         include_packages=["signalk-server"],
@@ -269,10 +269,10 @@ def test_matches_explicit_package_ignores_missing_metadata():
 
 def test_matches_multiple_tags_any():
     """Package needs to match ANY of the specified tags (OR logic)."""
-    pkg = create_mock_package("test-pkg", tags="field::marine, role::app")
+    pkg = create_mock_package("test-pkg", origin="Test Origin", tags="field::marine, role::app")
 
     filters = StoreFilter(
-        include_origins=[],
+        include_origins=["Test Origin"],
         include_sections=[],
         include_tags=["field::marine", "field::aviation"],  # Matches first
         include_packages=[],


### PR DESCRIPTION
## Summary

Make origin filtering mandatory for container stores and implement origin pre-filtering optimization for significant performance gains.

## Changes

### store_config.py
- Update `StoreFilter` to require non-empty `include_origins`
- Add clear error messages explaining performance rationale
- Document that container packages always come from custom repositories

### store_filter.py
- Implement origin pre-filtering optimization:
  - Pre-filter by origin first (fast operation)
  - Apply additional filters only to pre-filtered set
  - Add `_matches_additional_filters()` helper function
- Add debug logging showing percentage reduction
- Update `count_matching_packages()` to use optimized filtering

### Test Updates
- `test_store_config.py` - Test mandatory origins validation (17 tests)
- `test_store_filter.py` - Add "Test Origin" to all test cases (18 tests)
- All 35 tests passing

## Performance Benefits

**Before**: Iterates through all 60,000+ Debian packages for every filter check

**After**:
1. Pre-filter by origin → typically ~600 packages (1% of total)
2. Apply expensive tag/section filters only to the 600 packages
3. **Expected speedup: 10-50x** depending on filter complexity

## Debug Logging Example

```
Store 'marine': Origin pre-filter matched 587/63421 packages (99.1% reduction)
Store 'marine' matched 245 packages out of 63421 total (pre-filtered from 587 origin matches)
```

## Breaking Changes

⚠️ Store definitions must now include non-empty `include_origins`

However, this is **not breaking** for existing deployments:
- The marine store already has `include_origins: ["Hat Labs"]`
- All existing stores in the ecosystem already specify origins

## Test Plan

- [x] All unit tests passing
- [ ] Manual testing with marine store on test system
- [ ] Verify debug logging shows performance gains
- [ ] Confirm no regression in store filtering behavior

## Related PRs

- container-packaging-tools#XX - Adds store schema validation
- halos-marine-containers#XX - Updates documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)