### PR TITLE
fix: re-implement filter-packages and resolve search UI issues

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -97,6 +97,8 @@ const initialState: AppState = {
  */
 export function AppProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<AppState>(initialState);
+  // Track the latest package load request to ignore stale responses
+  const packageRequestIdRef = React.useRef(0);
 
   // Load stores on mount
   const loadStores = useCallback(async () => {
@@ -124,6 +126,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   // Load packages - reads from current state, no dependencies on state values
   const loadPackages = useCallback(async (params?: FilterParams) => {
+    // Increment request ID to track this request
+    const requestId = ++packageRequestIdRef.current;
+
     setState((prev) => {
       const filterParams: FilterParams = {
         store_id: params?.store_id ?? prev.activeStore ?? undefined,
@@ -136,17 +141,23 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       // Start loading
       filterPackages(filterParams)
         .then((response) => {
-          setState((current) => ({
-            ...current,
-            packages: response.packages,
-            totalPackageCount: response.total_count,
-            limitedResults: response.limited,
-            packagesLoading: false,
-          }));
+          // Only apply results if this is still the latest request
+          if (requestId === packageRequestIdRef.current) {
+            setState((current) => ({
+              ...current,
+              packages: response.packages,
+              totalPackageCount: response.total_count,
+              limitedResults: response.limited,
+              packagesLoading: false,
+            }));
+          }
         })
         .catch((e) => {
-          const error = e instanceof APTBridgeError ? e.message : String(e);
-          setState((current) => ({ ...current, packagesError: error, packagesLoading: false }));
+          // Only apply error if this is still the latest request
+          if (requestId === packageRequestIdRef.current) {
+            const error = e instanceof APTBridgeError ? e.message : String(e);
+            setState((current) => ({ ...current, packagesError: error, packagesLoading: false }));
+          }
         });
 
       return { ...prev, packages: [], packagesLoading: true, packagesError: null };


### PR DESCRIPTION
## Summary

This PR refactors the filter-packages command to remove container store dependencies and fixes two critical search UI issues that were causing confusing behavior.

## Changes

### Backend Refactoring
- **Removed container store code**: Simplified architecture by removing store-specific logic
- **Re-implemented filter-packages**: Now works with standard APT repositories without store dependencies
- **Added comprehensive tests**: New test suite for filter-packages command
- **Addressed code review comments**: Refactored based on feedback

### Frontend Fixes

#### Fix 1: Clear stale data during search
**Problem**: When searching, old package data remained visible while the loading spinner showed, causing confusion.

**Solution**: Clear the packages array immediately when starting a new search (AppContext.tsx:152).

#### Fix 2: Prevent race condition with concurrent requests
**Problem**: Multiple API requests could complete out of order, causing a brief flash of incorrect data:
1. Initial loadPackages (no filter) starts
2. User types search query, new loadPackages starts
3. Search results arrive first (correct)
4. Initial unfiltered results arrive second, briefly overwriting with wrong data

**Solution**: Added request ID tracking using a ref counter. Each request gets a unique ID, and only responses from the latest request update the UI state. Stale responses are ignored.

## Testing

### Backend
- ✅ All 129 backend tests pass
- ✅ Type checking passes
- ✅ Linting passes

### Frontend
- ✅ All 191 frontend tests pass
- ✅ Build succeeds
- ✅ Manual testing on halos.local confirms fixes work

### Manual Testing Results
**Before fixes:**
- Typing "node" showed spinner, then packages starting with "0ad", then correct results
- Confusing flashing behavior

**After fixes:**
- Typing "node" shows spinner, then only correct filtered results
- No flashing or stale data

## Impact

- Simplifies codebase by removing unused store logic
- Improves search UX by eliminating confusing data display during loading
- Prevents race conditions that could show incorrect results

🤖 Generated with [Claude Code](https://claude.com/claude-code)