### PR TITLE
fix: remove hard-coded hostname references from test scripts

### DIFF
--- a/compare-layouts.js
+++ b/compare-layouts.js
@@ -1,5 +1,19 @@
 #!/usr/bin/env node
+/**
+ * Compare layouts between different Cockpit views.
+ *
+ * Environment variables:
+ *   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
+ */
 const playwright = require('playwright');
+
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
 
 (async () => {
   const browser = await playwright.chromium.launch({ headless: true });
@@ -11,7 +25,7 @@ const playwright = require('playwright');
   const page = await context.newPage();
 
   try {
-    await page.goto('https://halos.local:9090/', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.fill('#login-user-input', 'claude');
     await page.fill('#login-password-input', 'claude123');
     await page.click('#login-button');
@@ -19,21 +33,21 @@ const playwright = require('playwright');
 
     // Capture Package Manager
     console.log('📸 Capturing Package Manager...');
-    await page.goto('https://halos.local:9090/packagemanager', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/packagemanager`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.waitForTimeout(2000);
     await page.screenshot({ path: '/tmp/packagemanager-view.png', fullPage: true });
     console.log('Saved: /tmp/packagemanager-view.png');
 
     // Capture APT
     console.log('📸 Capturing APT...');
-    await page.goto('https://halos.local:9090/apt', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/apt`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.waitForTimeout(2000);
     await page.screenshot({ path: '/tmp/apt-view.png', fullPage: true });
     console.log('Saved: /tmp/apt-view.png');
 
     // Capture Storage
     console.log('📸 Capturing Storage...');
-    await page.goto('https://halos.local:9090/storage', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/storage`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.waitForTimeout(2000);
     await page.screenshot({ path: '/tmp/storage-view-new.png', fullPage: true });
     console.log('Saved: /tmp/storage-view-new.png');

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,10 +2,22 @@
  * Playwright E2E Test Configuration
  *
  * Tests the cockpit-apt UI in a real Cockpit environment.
- * Requires Cockpit to be running on halos.local:9090.
+ * Requires Cockpit to be running on the target host.
+ *
+ * Environment variables:
+ *   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
  */
 
 import { defineConfig, devices } from '@playwright/test';
+
+// Require test host from environment
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  throw new Error(
+    'COCKPIT_TEST_HOST environment variable is required.\n' +
+    'Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090'
+  );
+}
 
 export default defineConfig({
   testDir: './e2e',
@@ -30,7 +42,7 @@ export default defineConfig({
 
   use: {
     // Base URL for tests
-    baseURL: 'https://halos.local:9090',
+    baseURL: `https://${testHost}`,
 
     // Collect trace on failure
     trace: 'on-first-retry',

--- a/frontend/test/e2e/simple-screenshot.mjs
+++ b/frontend/test/e2e/simple-screenshot.mjs
@@ -1,5 +1,16 @@
 // Simple screenshot test
+//
+// Environment variables:
+//   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
 import { chromium } from 'playwright';
+
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
 
 (async () => {
   const browser = await chromium.launch();
@@ -8,10 +19,10 @@ import { chromium } from 'playwright';
   });
   const page = await context.newPage();
 
-  console.log('Loading https://halos.local:9090/apt...');
+  console.log(`Loading ${baseUrl}/apt...`);
 
   try {
-    await page.goto('https://halos.local:9090/apt', { waitUntil: 'load', timeout: 10000 });
+    await page.goto(`${baseUrl}/apt`, { waitUntil: 'load', timeout: 10000 });
 
     await page.screenshot({ path: '/tmp/apt-page.png', fullPage: true });
     console.log('Screenshot saved to /tmp/apt-page.png');

--- a/frontend/test/e2e/test-css-loading.mjs
+++ b/frontend/test/e2e/test-css-loading.mjs
@@ -1,5 +1,16 @@
-// Test CSS loading on halos.local using Playwright
+// Test CSS loading using Playwright
+//
+// Environment variables:
+//   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
 import { chromium } from 'playwright';
+
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
 
 (async () => {
   const browser = await chromium.launch({
@@ -25,11 +36,11 @@ import { chromium } from 'playwright';
     }
   });
 
-  console.log('Loading https://halos.local:9090/...\n');
+  console.log(`Loading ${baseUrl}/...\n`);
 
   try {
     // First login to Cockpit
-    await page.goto('https://halos.local:9090/', {
+    await page.goto(`${baseUrl}/`, {
       waitUntil: 'networkidle',
       timeout: 30000
     });
@@ -45,7 +56,7 @@ import { chromium } from 'playwright';
     console.log('Logged in. Now loading /apt...\n');
 
     // Now navigate to apt
-    await page.goto('https://halos.local:9090/apt', {
+    await page.goto(`${baseUrl}/apt`, {
       waitUntil: 'networkidle',
       timeout: 30000
     });

--- a/inspect-html.js
+++ b/inspect-html.js
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 /**
  * Inspect the actual HTML structure
+ *
+ * Environment variables:
+ *   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
  */
 const playwright = require('playwright');
+
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
 
 (async () => {
   console.log('🔍 Inspecting HTML structure...\n');
@@ -16,14 +27,14 @@ const playwright = require('playwright');
   const page = await context.newPage();
 
   try {
-    await page.goto('https://halos.local:9090/', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.fill('#login-user-input', 'claude');
     await page.fill('#login-password-input', 'claude123');
     await page.click('#login-button');
     await page.waitForTimeout(2000);
 
     // Check APT
-    await page.goto('https://halos.local:9090/apt', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/apt`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.waitForTimeout(1000);
 
     const aptStructure = await page.evaluate(() => {
@@ -36,7 +47,7 @@ const playwright = require('playwright');
     console.log('\n---\n');
 
     // Check Storage for comparison
-    await page.goto('https://halos.local:9090/storage', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/storage`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.waitForTimeout(1000);
 
     const storageStructure = await page.evaluate(() => {

--- a/test-dark-theme.js
+++ b/test-dark-theme.js
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 /**
  * Test dark theme support
+ *
+ * Environment variables:
+ *   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
  */
 const playwright = require('playwright');
+
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
 
 (async () => {
   console.log('🌙 Testing dark theme...\n');
@@ -16,7 +27,7 @@ const playwright = require('playwright');
   const page = await context.newPage();
 
   try {
-    await page.goto('https://halos.local:9090/', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.fill('#login-user-input', 'claude');
     await page.fill('#login-password-input', 'claude123');
     await page.click('#login-button');
@@ -24,7 +35,7 @@ const playwright = require('playwright');
 
     // Navigate to APT (light theme by default)
     console.log('📸 Capturing light theme...');
-    await page.goto('https://halos.local:9090/apt', { waitUntil: 'networkidle', timeout: 10000 });
+    await page.goto(`${baseUrl}/apt`, { waitUntil: 'networkidle', timeout: 10000 });
     await page.waitForTimeout(1000);
     await page.screenshot({ path: '/tmp/apt-light.png', fullPage: true });
     console.log('Saved: /tmp/apt-light.png');

--- a/test-fresh.js
+++ b/test-fresh.js
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 /**
  * Test cockpit-apt layout with cache clearing
+ *
+ * Environment variables:
+ *   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
  */
 const playwright = require('playwright');
+
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
 
 (async () => {
   console.log('🧪 Testing cockpit-apt layout (cache cleared)...\n');
@@ -17,7 +28,7 @@ const playwright = require('playwright');
 
   try {
     console.log('📍 Navigating to login page...');
-    await page.goto('https://halos.local:9090/', {
+    await page.goto(`${baseUrl}/`, {
       waitUntil: 'networkidle',
       timeout: 10000
     });
@@ -31,7 +42,7 @@ const playwright = require('playwright');
 
     // Navigate to APT with cache bypass
     console.log('📍 Navigating to APT (bypassing cache)...');
-    await page.goto('https://halos.local:9090/apt', {
+    await page.goto(`${baseUrl}/apt`, {
       waitUntil: 'networkidle',
       timeout: 10000
     });

--- a/test-layout.js
+++ b/test-layout.js
@@ -1,10 +1,21 @@
 #!/usr/bin/env node
 /**
  * Test cockpit-apt layout and take screenshots
+ *
+ * Environment variables:
+ *   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
  */
 const playwright = require('playwright');
 const fs = require('fs');
 const path = require('path');
+
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
 
 (async () => {
   console.log('🧪 Testing cockpit-apt layout...\n');
@@ -34,7 +45,7 @@ const path = require('path');
 
   try {
     console.log('📍 Navigating to login page...');
-    await page.goto('https://halos.local:9090/', {
+    await page.goto(`${baseUrl}/`, {
       waitUntil: 'networkidle',
       timeout: 10000
     });
@@ -48,7 +59,7 @@ const path = require('path');
 
     // Navigate to APT
     console.log('📍 Navigating to APT...');
-    await page.goto('https://halos.local:9090/apt', {
+    await page.goto(`${baseUrl}/apt`, {
       waitUntil: 'networkidle',
       timeout: 10000
     });

--- a/test-storage-layout.js
+++ b/test-storage-layout.js
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 /**
  * Capture Storage page layout for comparison
+ *
+ * Environment variables:
+ *   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
  */
 const playwright = require('playwright');
+
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
 
 (async () => {
   console.log('📸 Capturing Storage page layout...\n');
@@ -17,7 +28,7 @@ const playwright = require('playwright');
 
   try {
     console.log('📍 Navigating to login page...');
-    await page.goto('https://halos.local:9090/', {
+    await page.goto(`${baseUrl}/`, {
       waitUntil: 'networkidle',
       timeout: 10000
     });
@@ -31,7 +42,7 @@ const playwright = require('playwright');
 
     // Navigate to Storage
     console.log('📍 Navigating to Storage...');
-    await page.goto('https://halos.local:9090/storage', {
+    await page.goto(`${baseUrl}/storage`, {
       waitUntil: 'networkidle',
       timeout: 10000
     });

--- a/test-tabs.js
+++ b/test-tabs.js
@@ -1,11 +1,22 @@
 #!/usr/bin/env node
 /**
- * Quick test to verify tabs work on halos.local
+ * Quick test to verify tabs work
+ *
+ * Environment variables:
+ *   COCKPIT_TEST_HOST - Required. The test host (e.g., myhostname.local:9090)
  */
 const { chromium } = require('playwright');
 
+const testHost = process.env.COCKPIT_TEST_HOST;
+if (!testHost) {
+  console.error('Error: COCKPIT_TEST_HOST environment variable is required.');
+  console.error('Set it to your Cockpit host, e.g.: export COCKPIT_TEST_HOST=myhostname.local:9090');
+  process.exit(1);
+}
+const baseUrl = `https://${testHost}`;
+
 (async () => {
-  console.log('🧪 Testing cockpit-apt tabs on halos.local...\n');
+  console.log(`🧪 Testing cockpit-apt tabs on ${testHost}...\n`);
 
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
@@ -32,8 +43,8 @@ const { chromium } = require('playwright');
   });
 
   try {
-    console.log('📍 Navigating to https://halos.local:9090/apt...');
-    await page.goto('https://halos.local:9090/apt', {
+    console.log(`📍 Navigating to ${baseUrl}/apt...`);
+    await page.goto(`${baseUrl}/apt`, {
       waitUntil: 'networkidle',
       timeout: 10000
     });


### PR DESCRIPTION
## Summary
Update all Playwright test scripts to require `COCKPIT_TEST_HOST` environment variable instead of using hard-coded hostnames.

## Changes
- `frontend/playwright.config.ts`: Use env var for baseURL
- All standalone test scripts (`compare-layouts.js`, `inspect-html.js`, `test-*.js`): Require COCKPIT_TEST_HOST
- Frontend e2e tests (`frontend/test/e2e/*.mjs`): Require COCKPIT_TEST_HOST

## Usage
To run tests, set the environment variable:
```bash
export COCKPIT_TEST_HOST=myhostname.local:9090
npm run test:e2e
```

## Test plan
- [ ] Verify lint check passes: `.github/scripts/check-hardcoded-hostnames.sh`
- [ ] Verify test scripts fail gracefully when COCKPIT_TEST_HOST is not set
- [ ] Verify test scripts work when COCKPIT_TEST_HOST is properly set

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)