### PR TITLE
fix(ui): wire Install/Remove handlers in SearchView, SectionPackageListView, InstalledView

### DIFF
--- a/frontend/src/apt.tsx
+++ b/frontend/src/apt.tsx
@@ -26,8 +26,10 @@ import {
 import { ArrowUpIcon, CubesIcon, LayerGroupIcon, SearchIcon } from "@patternfly/react-icons";
 import React, { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { ErrorAlert } from "./components/ErrorAlert";
 import { RepositoryDropdown } from "./components/RepositoryDropdown";
 import { AppProvider, useApp } from "./context/AppContext";
+import { installPackage, removePackage } from "./lib/api";
 import { InstalledView } from "./views/InstalledView";
 import { PackageDetailsView } from "./views/PackageDetailsView";
 import { SearchView } from "./views/SearchView";
@@ -113,6 +115,11 @@ function navigateTo(path: string) {
 function App() {
   const { state, actions } = useApp();
   const [route, setRoute] = useState<Route>(parseRoute(cockpit.location.path));
+  const [operationError, setOperationError] = useState<{
+    packageName: string;
+    operation: "install" | "remove";
+    error: Error;
+  } | null>(null);
 
   // Banner shown when package lists are missing AND we can't auto-refresh
   // them because the session lacks administrative access. Option (b) from the
@@ -146,19 +153,35 @@ function App() {
   const handleNavigateToUpdates = () => navigateTo("updates");
   const handleBack = () => window.history.back();
 
-  // Install/Remove notification handlers
-  // These are called AFTER the operation completes in child components
-  // Used for side effects like invalidating caches, showing notifications, etc.
+  // Install / Remove handlers for SearchView, SectionPackageListView, and
+  // InstalledView. PackageDetailsView performs its own install/remove with
+  // streamed progress, so these handlers are not passed to that view.
+  // Errors are surfaced via the top-level ErrorAlert banner instead of
+  // propagating to the caller, so the views' own loading-state cleanup runs.
   const handleInstall = async (packageName: string) => {
-    // Child component already performed the install
-    // Just log for now - could add toast notifications here
-    console.log("Package installed:", packageName);
+    setOperationError(null);
+    try {
+      await installPackage(packageName);
+    } catch (error) {
+      setOperationError({
+        packageName,
+        operation: "install",
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    }
   };
 
   const handleRemove = async (packageName: string) => {
-    // Child component already performed the remove
-    // Just log for now - could add toast notifications here
-    console.log("Package removed:", packageName);
+    setOperationError(null);
+    try {
+      await removePackage(packageName);
+    } catch (error) {
+      setOperationError({
+        packageName,
+        operation: "remove",
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    }
   };
 
   // Determine active tab
@@ -231,14 +254,7 @@ function App() {
         );
 
       case "package-details":
-        return (
-          <PackageDetailsView
-            packageName={route.params.name || ""}
-            onInstall={handleInstall}
-            onRemove={handleRemove}
-            onBack={handleBack}
-          />
-        );
+        return <PackageDetailsView packageName={route.params.name || ""} onBack={handleBack} />;
 
       case "installed":
         return (
@@ -275,6 +291,15 @@ function App() {
             Administrative access is required to refresh package lists. Enable administrative access
             in the top bar to update them.
           </Alert>
+        </PageSection>
+      )}
+      {operationError && (
+        <PageSection hasBodyWrapper={false}>
+          <ErrorAlert
+            error={operationError.error}
+            onDismiss={() => setOperationError(null)}
+            title={`${operationError.operation === "install" ? "Install" : "Remove"} failed: ${operationError.packageName}`}
+          />
         </PageSection>
       )}
       <PageSection hasBodyWrapper={false}>

--- a/frontend/src/views/PackageDetailsView.tsx
+++ b/frontend/src/views/PackageDetailsView.tsx
@@ -14,11 +14,7 @@
  * - Error handling with retry
  *
  * Usage:
- *   <PackageDetailsView
- *     packageName="nginx"
- *     onInstall={handleInstall}
- *     onRemove={handleRemove}
- *   />
+ *   <PackageDetailsView packageName="nginx" onBack={() => navigateBack()} />
  */
 
 import {
@@ -54,22 +50,11 @@ export interface PackageDetailsViewProps {
   /** Package name to display */
   packageName: string;
 
-  /** Callback when user installs the package */
-  onInstall?: (packageName: string) => Promise<void>;
-
-  /** Callback when user removes the package */
-  onRemove?: (packageName: string) => Promise<void>;
-
   /** Callback to navigate back */
   onBack?: () => void;
 }
 
-export const PackageDetailsView: React.FC<PackageDetailsViewProps> = ({
-  packageName,
-  onInstall,
-  onRemove,
-  onBack,
-}) => {
+export const PackageDetailsView: React.FC<PackageDetailsViewProps> = ({ packageName, onBack }) => {
   const { actions } = useApp();
   const { allowed: isAdminAllowed } = useAdminPermission();
   const isAdminRequired = isAdminAllowed !== true;
@@ -139,16 +124,6 @@ export const PackageDetailsView: React.FC<PackageDetailsViewProps> = ({
       } catch (e) {
         console.warn("Failed to reload global package state:", e);
       }
-
-      // Also call the optional parent callback for any side effects
-      if (onInstall) {
-        try {
-          await onInstall(details.name);
-        } catch (e) {
-          // Ignore errors from parent callback
-          console.warn("Parent onInstall callback failed:", e);
-        }
-      }
     } catch (error) {
       setOperationError(error instanceof Error ? error : new Error(String(error)));
     } finally {
@@ -177,16 +152,6 @@ export const PackageDetailsView: React.FC<PackageDetailsViewProps> = ({
         await actions.loadPackages();
       } catch (e) {
         console.warn("Failed to reload global package state:", e);
-      }
-
-      // Also call the optional parent callback for any side effects
-      if (onRemove) {
-        try {
-          await onRemove(details.name);
-        } catch (e) {
-          // Ignore errors from parent callback
-          console.warn("Parent onRemove callback failed:", e);
-        }
       }
     } catch (error) {
       setOperationError(error instanceof Error ? error : new Error(String(error)));

--- a/frontend/src/views/__tests__/InstalledView.test.tsx
+++ b/frontend/src/views/__tests__/InstalledView.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Package } from "../../api/types";
+import { InstalledView } from "../InstalledView";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).cockpit = {
+  spawn: vi.fn(),
+  file: vi.fn(),
+  location: { path: [], options: {}, go: vi.fn() },
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  transport: { control: vi.fn() },
+};
+
+const installedPackage: Package = {
+  name: "curl",
+  version: "8.5.0-1",
+  installedVersion: "8.5.0-1",
+  candidateVersion: "8.5.0-1",
+  installed: true,
+  upgradable: false,
+  summary: "command line tool for transferring data with URL syntax",
+  section: "web",
+  architecture: "arm64",
+};
+
+const stableContext = {
+  state: {
+    packages: [installedPackage],
+    packagesLoading: false,
+    packagesError: null,
+  },
+  actions: {
+    setActiveTab: vi.fn(),
+    loadPackages: vi.fn().mockResolvedValue(undefined),
+  },
+};
+
+vi.mock("../../context/AppContext", () => ({
+  useApp: () => stableContext,
+}));
+
+vi.mock("../../hooks/useAdminPermission", () => ({
+  useAdminPermission: () => ({ allowed: true }),
+}));
+
+describe("InstalledView - parent handler wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invokes onRemove with the package name when Remove is clicked", async () => {
+    const onRemove = vi.fn().mockResolvedValue(undefined);
+
+    render(<InstalledView onNavigateToPackage={vi.fn()} onRemove={onRemove} />);
+
+    const removeButton = await screen.findByRole("button", { name: "Remove" });
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(onRemove).toHaveBeenCalledWith("curl");
+    });
+  });
+});

--- a/frontend/src/views/__tests__/SearchView.test.tsx
+++ b/frontend/src/views/__tests__/SearchView.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Package } from "../../api/types";
+import { SearchView } from "../SearchView";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).cockpit = {
+  spawn: vi.fn(),
+  file: vi.fn(),
+  location: { path: [], options: {}, go: vi.fn() },
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  transport: { control: vi.fn() },
+};
+
+const installablePackage: Package = {
+  name: "htop",
+  version: "3.3.0-2",
+  installedVersion: undefined,
+  candidateVersion: "3.3.0-2",
+  installed: false,
+  upgradable: false,
+  summary: "interactive process viewer",
+  section: "utils",
+  architecture: "arm64",
+};
+
+const installedPackage: Package = {
+  name: "curl",
+  version: "8.5.0-1",
+  installedVersion: "8.5.0-1",
+  candidateVersion: "8.5.0-1",
+  installed: true,
+  upgradable: false,
+  summary: "command line tool for transferring data with URL syntax",
+  section: "web",
+  architecture: "arm64",
+};
+
+vi.mock("../../context/AppContext", () => ({
+  useApp: () => ({
+    state: {
+      packages: [installablePackage, installedPackage],
+      packagesLoading: false,
+      packagesError: null,
+      searchQuery: "ht",
+      limitedResults: false,
+    },
+    actions: {
+      setActiveTab: vi.fn(),
+      setSearchQuery: vi.fn(),
+      loadPackages: vi.fn().mockResolvedValue(undefined),
+      clearError: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("../../hooks/useAdminPermission", () => ({
+  useAdminPermission: () => ({ allowed: true }),
+}));
+
+describe("SearchView - parent handler wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invokes onInstall with the package name when Install is clicked", async () => {
+    const onInstall = vi.fn().mockResolvedValue(undefined);
+    const onRemove = vi.fn().mockResolvedValue(undefined);
+
+    render(<SearchView onInstall={onInstall} onRemove={onRemove} />);
+
+    const installButton = await screen.findByRole("button", { name: "Install" });
+    fireEvent.click(installButton);
+
+    await waitFor(() => {
+      expect(onInstall).toHaveBeenCalledWith("htop");
+    });
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it("invokes onRemove with the package name when Remove is clicked", async () => {
+    const onInstall = vi.fn().mockResolvedValue(undefined);
+    const onRemove = vi.fn().mockResolvedValue(undefined);
+
+    render(<SearchView onInstall={onInstall} onRemove={onRemove} />);
+
+    const removeButton = await screen.findByRole("button", { name: "Remove" });
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(onRemove).toHaveBeenCalledWith("curl");
+    });
+    expect(onInstall).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/views/__tests__/SectionPackageListView.test.tsx
+++ b/frontend/src/views/__tests__/SectionPackageListView.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Package } from "../../api/types";
+import { SectionPackageListView } from "../SectionPackageListView";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).cockpit = {
+  spawn: vi.fn(),
+  file: vi.fn(),
+  location: { path: [], options: {}, go: vi.fn() },
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  transport: { control: vi.fn() },
+};
+
+const installablePackage: Package = {
+  name: "htop",
+  version: "3.3.0-2",
+  installedVersion: undefined,
+  candidateVersion: "3.3.0-2",
+  installed: false,
+  upgradable: false,
+  summary: "interactive process viewer",
+  section: "utils",
+  architecture: "arm64",
+};
+
+const installedPackage: Package = {
+  name: "curl",
+  version: "8.5.0-1",
+  installedVersion: "8.5.0-1",
+  candidateVersion: "8.5.0-1",
+  installed: true,
+  upgradable: false,
+  summary: "command line tool for transferring data with URL syntax",
+  section: "utils",
+  architecture: "arm64",
+};
+
+vi.mock("../../context/AppContext", () => ({
+  useApp: () => ({
+    state: { packages: [], packagesLoading: false, packagesError: null },
+    actions: { loadPackages: vi.fn().mockResolvedValue(undefined) },
+  }),
+}));
+
+vi.mock("../../hooks/useAdminPermission", () => ({
+  useAdminPermission: () => ({ allowed: true }),
+}));
+
+const mockListPackagesBySection = vi.fn();
+vi.mock("../../lib/api", () => ({
+  listPackagesBySection: (...args: unknown[]) => mockListPackagesBySection(...args),
+}));
+
+describe("SectionPackageListView - parent handler wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPackagesBySection.mockResolvedValue([installablePackage, installedPackage]);
+  });
+
+  it("invokes onInstall with the package name when Install is clicked", async () => {
+    const onInstall = vi.fn().mockResolvedValue(undefined);
+    const onRemove = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <SectionPackageListView
+        sectionName="utils"
+        onNavigateToPackage={vi.fn()}
+        onNavigateToSections={vi.fn()}
+        onInstall={onInstall}
+        onRemove={onRemove}
+      />
+    );
+
+    const installButton = await screen.findByRole("button", { name: "Install" });
+    fireEvent.click(installButton);
+
+    await waitFor(() => {
+      expect(onInstall).toHaveBeenCalledWith("htop");
+    });
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it("invokes onRemove with the package name when Remove is clicked", async () => {
+    const onInstall = vi.fn().mockResolvedValue(undefined);
+    const onRemove = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <SectionPackageListView
+        sectionName="utils"
+        onNavigateToPackage={vi.fn()}
+        onNavigateToSections={vi.fn()}
+        onInstall={onInstall}
+        onRemove={onRemove}
+      />
+    );
+
+    const removeButton = await screen.findByRole("button", { name: "Remove" });
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(onRemove).toHaveBeenCalledWith("curl");
+    });
+    expect(onInstall).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

The `handleInstall` / `handleRemove` callbacks in `apt.tsx:136-146`
were `console.log` stubs. Clicking Install in `SearchView` or
`SectionPackageListView`, or Remove in `InstalledView`, did nothing
regardless of permissions. Only `PackageDetailsView`'s own inline
install/remove path was actually functional.

Identified during the audit in halos-org/halos#121; closes
`halos-org/cockpit-apt#155`.

## What changed

- `apt.tsx`: replace the two stub handlers with real `installPackage`
  / `removePackage` calls from `lib/api`. Errors are captured into a
  new `operationError` state and surfaced via a top-level
  `ErrorAlert` titled "Install failed: <package>" or "Remove failed:
  <package>". Errors are not propagated to the calling views, so each
  view's own `setOperatingPackage(null)` / `setActioningPackage(null)`
  cleanup runs unchanged.
- `apt.tsx`: stop passing `onInstall` / `onRemove` to
  `PackageDetailsView`. That view already performs its own streaming
  install/remove with progress UI and inline `ErrorAlert` (added in
  #154); the parent callback was only a "notify completion" hook.
  Now that the parent stubs do real installs, calling them after
  `PackageDetailsView`'s own install would double-install. The props
  were already declared optional and guarded with `if (onInstall)` /
  `if (onRemove)`, so making them undefined is a no-op for that view.

## Dependency

This PR is stacked on **halos-org/cockpit-apt#156** (gating fix for
issue #154). The gating must land first so the buttons are
admin-gated before they go live. When #156 merges, GitHub will
auto-rebase this PR onto `main`.

## Verification

- `npm run typecheck` clean.
- `npm run lint` clean.
- `npm test`: 213 tests pass (same pre-existing `apt.test.ts`
  localStorage failure unrelated to this change).
- Manual verification path: with admin granted, click Install on a
  package in `SearchView` results; package becomes installed; row
  state updates. Same for Remove from `InstalledView` and Install /
  Remove from `SectionPackageListView`. Forced backend error
  (`installPackage` rejects) surfaces the `ErrorAlert` banner with
  the failing package name.

## Refs

- Cross-module audit: halos-org/halos#121
- Gating PR (this module): halos-org/cockpit-apt#156
- Pilot: halos-org/cockpit-container-apps#80
